### PR TITLE
Allow skipping cert verification

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,19 +3,19 @@ workflow "push" {
   resolves = ["docker-publish-latest"]
 }
 
-action "not-branch-del-tag" {
+action "not-branch-del" {
   uses = "actions/bin/filter@master"
   args = "not deleted"
 }
 
 action "docker-auth" {
-  needs = ["not-branch-del-tag"]
+  needs = ["not-branch-del"]
   uses = "actions/docker/login@master"
   secrets = ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
 }
 
 action "docker-build" {
-  needs = ["not-branch-del-tag"]
+  needs = ["not-branch-del"]
   uses = "actions/docker/cli@master"
   args = "build -t blupig/httptest:dev --build-arg BUILD_BRANCH=${GITHUB_REF} --build-arg BUILD_COMMIT=${GITHUB_SHA} ."
 }

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ tests:
     conditions:                  # Specify conditions. Test only runs when all conditions are met
       env:                       # Matches an environment variable
         TEST_ENV: '^(dev|stg)$'  # Environment variable name : regular expression
+    skipCertVerification: false  # Set true to skip verification of server TLS certificate (insecure and not recommended)
 
     request:                     # Request to send
       scheme: 'https'            # URL scheme. Only http and https are supported. Default: https

--- a/coordinator.go
+++ b/coordinator.go
@@ -56,7 +56,7 @@ func RunTests(tests []*Test, config *Config) bool {
 				}
 			} else if len(result.Errors) > 0 {
 				failed++
-				fmt.Printf("failed: %s\n", testInfoString)
+				fmt.Printf("\nfailed: %s\n", testInfoString)
 				for _, err := range result.Errors {
 					fmt.Printf("%s\n", err.Error())
 				}

--- a/example-tests/httpbin.yml
+++ b/example-tests/httpbin.yml
@@ -53,7 +53,7 @@ tests:
     response:
       statusCodes: [300]
 
-  # This test will fail
+  # Multiple failures
   - description: 'HTTP status code - 400'
     request:
       path: '/status/400'
@@ -88,3 +88,12 @@ tests:
       body:
         patterns:
           - 'e4q2jezpkyv1q3a9'
+
+  # Different host and allow invalid cert
+  - description: 'invalid server cert'
+    skipCertVerification: true
+    request:
+      host: 'wrong.host.badssl.com'
+      path: '/'
+    response:
+      statusCodes: [200]

--- a/http.go
+++ b/http.go
@@ -103,6 +103,9 @@ func SendHTTPRequest(config *HTTPRequestConfig) (*http.Response, []byte, error) 
 	}
 
 	client := http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 		Transport: transport,
 		Timeout:   time.Duration(config.TimeoutSeconds * time.Second),
 	}

--- a/http.go
+++ b/http.go
@@ -24,6 +24,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,15 +33,16 @@ import (
 
 // HTTPRequestConfig type
 type HTTPRequestConfig struct {
-	Method            string
-	URL               string
-	QueryParams       map[string]string
-	Headers           map[string]string
-	BasicAuthUsername string
-	BasicAuthPassword string
-	Body              io.Reader
-	Attempts          int
-	TimeoutSeconds    time.Duration
+	Method               string
+	URL                  string
+	QueryParams          map[string]string
+	Headers              map[string]string
+	BasicAuthUsername    string
+	BasicAuthPassword    string
+	Body                 io.Reader
+	Attempts             int
+	TimeoutSeconds       time.Duration
+	SkipCertVerification bool
 }
 
 // SendHTTPRequest sends an HTTP request and returns response body and status
@@ -96,8 +98,13 @@ func SendHTTPRequest(config *HTTPRequestConfig) (*http.Response, []byte, error) 
 		req.Header.Add(k, v)
 	}
 
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: config.SkipCertVerification},
+	}
+
 	client := http.Client{
-		Timeout: time.Duration(config.TimeoutSeconds * time.Second),
+		Transport: transport,
+		Timeout:   time.Duration(config.TimeoutSeconds * time.Second),
 	}
 
 	// Start sending request

--- a/parser.go
+++ b/parser.go
@@ -44,7 +44,8 @@ type Test struct {
 	Conditions  struct {
 		Env map[string]string `yaml:"env"`
 	} `yaml:"conditions"`
-	Request struct {
+	SkipCertVerification bool `yaml:"skipCertVerification"`
+	Request              struct {
 		Scheme  string            `yaml:"scheme"`
 		Host    string            `yaml:"host"`
 		Method  string            `yaml:"method"`

--- a/tester.go
+++ b/tester.go
@@ -71,12 +71,13 @@ func RunTest(test *Test, defaultHost string) *TestResult {
 	}
 
 	reqConfig := &HTTPRequestConfig{
-		Method:         test.Request.Method,
-		URL:            url,
-		Headers:        test.Request.Headers,
-		Body:           body,
-		Attempts:       1,
-		TimeoutSeconds: 5,
+		Method:               test.Request.Method,
+		URL:                  url,
+		Headers:              test.Request.Headers,
+		Body:                 body,
+		Attempts:             1,
+		TimeoutSeconds:       5,
+		SkipCertVerification: test.SkipCertVerification,
 	}
 
 	resp, respBody, err := SendHTTPRequest(reqConfig)

--- a/tester.go
+++ b/tester.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
 	"regexp"
 	"strings"
 )
@@ -63,7 +62,11 @@ func RunTest(test *Test, defaultHost string) *TestResult {
 		return result
 	}
 
-	url := test.Request.Scheme + "://" + test.Request.Host + path.Join("/", test.Request.Path)
+	if !strings.HasPrefix(test.Request.Path, "/") {
+		result.Errors = append(result.Errors, fmt.Errorf("request.path must start with /"))
+		return result
+	}
+	url := test.Request.Scheme + "://" + test.Request.Host + test.Request.Path
 
 	var body io.Reader
 	if len(test.Request.Body) > 0 {


### PR DESCRIPTION
Also fixed a few issues:
- Stop following redirections
- Keep exact original request path and require `/` at beginning
